### PR TITLE
Added support for gnome-shell 3.21 & 3.21.91

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,9 @@
         "3.14",
         "3.16",
         "3.18",
-        "3.20"
+        "3.20",
+        "3.21",
+        "3.21.91"
     ],
     "uuid": "gnome-shell-audio-output-switcher@kgaut",
     "name": "Gnome Shell Audio Output Switcher",


### PR DESCRIPTION
Debian Stretch just got gnome-shell 3.21.91 so I needed to bump the version.
3.21 didn't work for version 3.21.91, only works with the patch version explicitly named.
I assume that 3.21 should work also since it is between 3.20 and 3.21.91.
