### PR TITLE
Fix invalid assignments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.eslintrc.json
 *~
 *.zip

--- a/extension.js
+++ b/extension.js
@@ -6,18 +6,18 @@ const AudioOutputSubMenu = new Lang.Class({
 	Name: 'AudioOutputSubMenu',
 	Extends: PopupMenu.PopupSubMenuMenuItem,
 
-	_init: function() {
+	_init: function () {
 		this.parent('Audio Output: Connecting...', true);
 
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
-		this._controlSignal = this._control.connect('default-sink-changed', Lang.bind(this, function() {
+		this._controlSignal = this._control.connect('default-sink-changed', Lang.bind(this, function () {
 			this._updateDefaultSink();
 		}));
 
 		this._updateDefaultSink();
 
-		this.menu.connect('open-state-changed', Lang.bind(this, function(menu, isOpen) {
+		this.menu.connect('open-state-changed', Lang.bind(this, function (menu, isOpen) {
 			if (isOpen)
 				this._updateSinkList();
 		}));
@@ -28,10 +28,10 @@ const AudioOutputSubMenu = new Lang.Class({
 	},
 
 	_updateDefaultSink: function () {
-		defsink = this._control.get_default_sink();
+		let defsink = this._control.get_default_sink();
 		//Unfortunately, Gvc neglects some pulse-devices, such as all "Monitor of ..."
-		if (defsink == null)
-			this.label.set_text("Other");
+		if (typeof (defsink) === 'undefined' || defsink === null)
+			this.label.set_text('Other');
 		else
 			this.label.set_text(defsink.get_description());
 	},
@@ -43,24 +43,23 @@ const AudioOutputSubMenu = new Lang.Class({
 		let sinklist = this._control.get_sinks();
 		let control = this._control;
 
-		for (let i=0; i<sinklist.length; i++) {
+		for (let i = 0; i < sinklist.length; i++) {
 			let sink = sinklist[i];
 			if (sink === defsink)
 				continue;
 			let item = new PopupMenu.PopupMenuItem(sink.get_description());
-			item.connect('activate', Lang.bind(sink, function() {
+			item.connect('activate', Lang.bind(sink, function () {
 				control.set_default_sink(this);
 			}));
 			this.menu.addMenuItem(item);
 		}
-		if (sinklist.length == 0 ||
-			(sinklist.length == 1 && sinklist[0] === defsink)) {
-			item = new PopupMenu.PopupMenuItem("No more Devices");
+		if (sinklist.length === 0 || (sinklist.length === 1 && sinklist[0] === defsink)) {
+			let item = new PopupMenu.PopupMenuItem('No More Devices');
 			this.menu.addMenuItem(item);
 		}
 	},
 
-	destroy: function() {
+	destroy: function () {
 		this._control.disconnect(this._controlSignal);
 		this.parent();
 	}
@@ -72,7 +71,7 @@ function init() {
 }
 
 function enable() {
-	if (audioOutputSubMenu != null)
+	if (audioOutputSubMenu !== null)
 		return;
 	audioOutputSubMenu = new AudioOutputSubMenu();
 
@@ -85,7 +84,7 @@ function enable() {
 			break;
 		else
 			i++;
-	volMen.addMenuItem(audioOutputSubMenu, i+1);
+	volMen.addMenuItem(audioOutputSubMenu, i + 1);
 }
 
 function disable() {


### PR DESCRIPTION
This fixes invalid assignments at lines 31 and 58 which throw warnings every time the extension invokes them. It also standardizes the use of '===' and makes the formatting cohesive.
